### PR TITLE
✨ NEW: Add `glob` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ The value of the `doc` key will be a path to a file (relative to the `conf.py`) 
 Each document can only occur once in the ToC!
 ```
 
-Documents can then have a `parts` key - denoting a list of individual toctrees for that document - and in-turn each part should have a `sections` key - denoting a list child documents/URLs.
+Document pages can then have a `parts` key - denoting a list of individual toctrees for that document - and in-turn each part should have a `sections` key - denoting a list of children links, that are one of: `doc`, `url` or `glob`:
+
+- `doc`: relating to a single document page (as above)
+- `glob`: relating to one or more document pages *via* Unix shell-style wildcards (similar to [`fnmatch`](https://docs.python.org/3/library/fnmatch.html), but single stars don't match slashes.)
+- `url`: relating to an external URL (`http` or `https`)
+
 This can proceed recursively to any depth.
 
 ```yaml
@@ -51,6 +56,7 @@ main:
       - sections:
         - doc: doc2
         - url: https://example.com
+        - glob: other*
 ```
 
 As a shorthand, the `sections` key can be at the same level as the `doc`, which denotes a document with a single `part`.
@@ -64,6 +70,7 @@ main:
     sections:
     - doc: doc2
     - url: https://example.com
+    - glob: other*
 ```
 
 ### Titles and Captions
@@ -166,6 +173,20 @@ To build a template site from only a ToC file:
 $ sphinx-etoc create-site -p path/to/site -e rst path/to/_toc.yml
 ```
 
+Note, when using `glob` you can also add additional files in `meta`/`create_additional`, e.g.
+
+```yaml
+main:
+  doc: intro
+  sections:
+  - glob: doc*
+meta:
+  create_additional:
+  - doc1
+  - doc2
+  - doc3
+```
+
 ## Development Notes
 
 Want to have a built-in CLI including commands:
@@ -187,11 +208,10 @@ Questions / TODOs:
 - What if toctree directive found in file? (raise incompatibility error/warnings)
 - Should `titlesonly` default to `True` (as in jupyter-book)?
 - nested numbered toctree not allowed (logs warning), so should be handled if `numbered: true` is in defaults
-- Handle globbing in sections (separate `glob` key?), also deal with in `create_site_from_toc`
 - Add additional top-level keys, e.g. `appendices` and `bibliography`
 - testing against Windows
 - option to add files not in toc to `ignore_paths` (including glob)
-
+- Add tests for "bad" toc files
 
 [github-ci]: https://github.com/executablebooks/sphinx-external-toc/workflows/continuous-integration/badge.svg?branch=main
 [github-link]: https://github.com/executablebooks/sphinx-external-toc

--- a/sphinx_external_toc/tools.py
+++ b/sphinx_external_toc/tools.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from pathlib import Path, PurePosixPath
 from os import linesep
 from typing import Union
@@ -15,6 +16,9 @@ def create_site_from_toc(
 ) -> Path:
     """Create the files defined in the external toc file.
 
+    Additional files can also be created by defining them in
+    `meta`/`create_additional` of the toc
+
     :param toc_path: Path to ToC.
     :param root_path: The root directory , or use ToC file directory.
     :param default_ext: The default file extension to use.
@@ -28,7 +32,7 @@ def create_site_from_toc(
 
     root_path = Path(toc_path).parent if root_path is None else Path(root_path)
 
-    for docname in site_map:
+    for docname in chain(site_map, site_map.meta.get("create_additional", [])):
         if not any(docname.endswith(ext) for ext in {".rst", ".md"}):
             docname += default_ext
         docpath = root_path.joinpath(PurePosixPath(docname))

--- a/tests/_toc_files/glob.yml
+++ b/tests/_toc_files/glob.yml
@@ -1,0 +1,10 @@
+main:
+  doc: intro
+  title: Introduction
+  sections:
+  - glob: doc*
+meta:
+  create_additional:
+  - doc1
+  - doc2
+  - doc3

--- a/tests/test_api/test_file_to_sitemap_glob_.yml
+++ b/tests/test_api/test_file_to_sitemap_glob_.yml
@@ -1,0 +1,16 @@
+_meta:
+  create_additional:
+  - doc1
+  - doc2
+  - doc3
+_root: intro
+intro:
+  docname: intro
+  parts:
+  - caption: null
+    numbered: false
+    reversed: false
+    sections:
+    - doc*
+    titlesonly: true
+  title: Introduction

--- a/tests/test_tools/test_file_to_sitemap_glob_.yml
+++ b/tests/test_tools/test_file_to_sitemap_glob_.yml
@@ -1,0 +1,4 @@
+- doc1.rst
+- doc2.rst
+- doc3.rst
+- intro.rst


### PR DESCRIPTION
Store toctree list items as one of:
`GlobItem`, `RefItem`, `UrlItem`,
add glob logic to `append_toctrees`,
add addtional file creation to `create_site_from_toc`.