### PR TITLE
✨ NEW: Add `tableofcontents` directive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@
 exclude: >
     (?x)^(
       \.vscode/settings\.json|
+      tests/.*xml|
     )$
 
 repos:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ main:
 
 You can also **limit the TOC numbering depth** by setting the `numbered` flag to an integer instead of `true`, e.g., `numbered: 3`.
 
+:::{note}
+By default, section numbering restarts for each `part`.
+If you want want this numbering to be continuous, check-out the [sphinx-multitoc-numbering extension](https://github.com/executablebooks/sphinx-multitoc-numbering).
+:::
+
 ### Defaults
 
 To have e.g. `numbered` added to all toctrees, set it under a `defaults` top-level key:
@@ -131,6 +136,26 @@ main:
 ```
 
 Available keys: `numbered`, `titlesonly`, `reversed`
+
+## Add a ToC to a page's content
+
+By default, the `toctree` generated per document (one per `part`) are appended to the end of the document and hidden (then, for example, most HTML themes show them in a side-bar).
+But if you would like them to be visible at a certain place within the document body, you may do so by using the `tableofcontents` directive:
+
+ReStructuredText:
+
+```restructuredtext
+.. tableofcontents::
+```
+
+MyST Markdown:
+
+````md
+```{tableofcontents}
+```
+````
+
+Currently, only one `tableofcontents` should be used per page (all `toctree` will be added here), and only if it is a page with child/descendant documents.
 
 ## Excluding files not in ToC
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Questions / TODOs:
   it will add `doc.rst` to the excluded patterns but then, when looking for `doc.md`,
   will still select `doc.rst` (since it is first in `source_suffix`).
   Maybe open an issue on sphinx, that `doc2path` should respect exclude patterns.
-
+- Intergrate https://github.com/executablebooks/sphinx-multitoc-numbering into this extension? (or upstream PR)
 
 [github-ci]: https://github.com/executablebooks/sphinx-external-toc/workflows/continuous-integration/badge.svg?branch=main
 [github-link]: https://github.com/executablebooks/sphinx-external-toc

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -4,11 +4,13 @@ defaults:
 main:
   file: intro
   title: Introduction
-  sections:
-  - file: doc1
-  - file: doc2
-    sections:
-    - file: subfolder/doc3
-    - url: https://example.com
-      title: Example Link
-  - glob: subglobs/glob*
+  parts:
+  - sections:
+    - file: doc1
+    - file: doc2
+      sections:
+      - file: subfolder/doc3
+      - url: https://example.com
+        title: Example Link
+  - sections:
+    - glob: subglobs/glob*

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,10 @@
 # sphinx-external-toc [IN-DEVELOPMENT]
 
-A sphinx extension that allows the documentation toctree to be defined in a single file.
+A sphinx extension that allows the documentation toctree to be defined in a single YAML file.
 
 In normal Sphinx documentation, the documentation structure is defined *via* a bottom-up approach - adding [`toctree` directives](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents) within pages of the documentation.
 
 This extension facilitates a **top-down** approach to defining the structure, within a single file that is external to the documentation.
+
+```{tableofcontents}
+```

--- a/sphinx_external_toc/__init__.py
+++ b/sphinx_external_toc/__init__.py
@@ -11,7 +11,12 @@ if TYPE_CHECKING:
 
 def setup(app: "Sphinx") -> dict:
     """Initialize the Sphinx extension."""
-    from .events import add_changed_toctrees, append_toctrees, parse_toc_to_env
+    from .events import (
+        add_changed_toctrees,
+        insert_toctrees,
+        parse_toc_to_env,
+        TableofContents,
+    )
 
     # variables
     app.add_config_value("external_toc_path", "_toc.yml", "env")
@@ -22,7 +27,8 @@ def setup(app: "Sphinx") -> dict:
     # it will always mark the config as changed in the env setup and re-build everything
     app.connect("config-inited", parse_toc_to_env, priority=900)
     app.connect("env-get-outdated", add_changed_toctrees)
+    app.add_directive("tableofcontents", TableofContents)
     # Note: this needs to occur before `TocTreeCollector.process_doc` (default priority 500)
-    app.connect("doctree-read", append_toctrees, priority=100)
+    app.connect("doctree-read", insert_toctrees, priority=100)
 
     return {"version": __version__, "parallel_read_safe": True}

--- a/tests/_toc_files/basic.yml
+++ b/tests/_toc_files/basic.yml
@@ -13,3 +13,5 @@ main:
         - sections:
           - file: subfolder/doc4
           - url: https://example.com
+meta:
+  regress: intro

--- a/tests/_toc_files/basic_compressed.yml
+++ b/tests/_toc_files/basic_compressed.yml
@@ -10,3 +10,5 @@ main:
     sections:
     - file: doc4
     - url: https://example.com
+meta:
+  regress: intro

--- a/tests/_toc_files/tableofcontents.yml
+++ b/tests/_toc_files/tableofcontents.yml
@@ -1,0 +1,12 @@
+main:
+  file: intro
+  parts:
+  - sections:
+    - file: doc1
+  - sections:
+    - file: doc2
+meta:
+  create_append:
+    intro: |
+      .. tableofcontents::
+  regress: intro

--- a/tests/_warning_toc_files/multiple_tableofcontents.yml
+++ b/tests/_warning_toc_files/multiple_tableofcontents.yml
@@ -1,0 +1,11 @@
+main:
+  file: intro
+  sections:
+  - file: doc1
+meta:
+  create_append:
+    intro: |
+      .. tableofcontents::
+
+      .. tableofcontents::
+  expected_warning: more than one tableofcontents directive

--- a/tests/_warning_toc_files/tableofcontents_no_toc.yml
+++ b/tests/_warning_toc_files/tableofcontents_no_toc.yml
@@ -1,0 +1,7 @@
+main:
+  file: intro
+meta:
+  create_append:
+    intro: |
+      .. tableofcontents::
+  expected_warning: tableofcontents directive in document with no descendants

--- a/tests/test_api/test_file_to_sitemap_basic_.yml
+++ b/tests/test_api/test_file_to_sitemap_basic_.yml
@@ -1,3 +1,5 @@
+_meta:
+  regress: intro
 _root: intro
 doc1:
   docname: doc1

--- a/tests/test_api/test_file_to_sitemap_tableofcontents_.yml
+++ b/tests/test_api/test_file_to_sitemap_tableofcontents_.yml
@@ -1,4 +1,8 @@
 _meta:
+  create_append:
+    intro: '.. tableofcontents::
+
+      '
   regress: intro
 _root: intro
 doc1:
@@ -9,31 +13,19 @@ doc2:
   docname: doc2
   parts: []
   title: null
-doc3:
-  docname: doc3
+intro:
+  docname: intro
   parts:
   - caption: null
     numbered: false
     reversed: false
     sections:
-    - doc4
-    - title: null
-      url: https://example.com
+    - doc1
     titlesonly: true
-  title: null
-doc4:
-  docname: doc4
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
   - caption: null
-    numbered: true
+    numbered: false
     reversed: false
     sections:
-    - doc1
     - doc2
-    - doc3
     titlesonly: true
-  title: Introduction
+  title: null

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -56,12 +56,11 @@ def sphinx_build_factory(make_app):
 @pytest.mark.parametrize(
     "path", TOC_FILES, ids=[path.name.rsplit(".", 1)[0] for path in TOC_FILES]
 )
-def test_success(path: Path, tmp_path: Path, sphinx_build_factory):
+def test_success(path: Path, tmp_path: Path, sphinx_build_factory, file_regression):
     """Test successful builds."""
     src_dir = tmp_path / "srcdir"
     # write document files
     site_map = create_site_from_toc(path, root_path=src_dir)
-    print(list(src_dir.glob("**/*")))
     # write conf.py
     src_dir.joinpath("conf.py").write_text(
         CONF_CONTENT
@@ -75,6 +74,11 @@ def test_success(path: Path, tmp_path: Path, sphinx_build_factory):
     # run sphinx
     builder = sphinx_build_factory(src_dir)
     builder.build()
+    # optionally check the doctree of a file
+    if "regress" in site_map.meta:
+        doctree = builder.app.env.get_doctree(site_map.meta["regress"])
+        doctree["source"] = site_map.meta["regress"]
+        file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sphinx/test_success_basic_.xml
+++ b/tests/test_sphinx/test_success_basic_.xml
@@ -1,0 +1,6 @@
+<document source="intro">
+    <section ids="heading-intro-rst" names="heading:\ intro.rst">
+        <title>
+            Heading: intro.rst
+        <compound classes="toctree-wrapper">
+            <toctree caption="Part Caption" entries="(None,\ 'doc1') (None,\ 'doc2') (None,\ 'doc3')" glob="False" hidden="True" includefiles="doc1 doc2 doc3" includehidden="False" maxdepth="-1" numbered="True" parent="intro" rawcaption="Part Caption" titlesonly="True">

--- a/tests/test_sphinx/test_success_basic_compressed_.xml
+++ b/tests/test_sphinx/test_success_basic_compressed_.xml
@@ -1,0 +1,6 @@
+<document source="intro">
+    <section ids="heading-intro-rst" names="heading:\ intro.rst">
+        <title>
+            Heading: intro.rst
+        <compound classes="toctree-wrapper">
+            <toctree caption="True" entries="(None,\ 'doc1') (None,\ 'doc2') (None,\ 'doc3')" glob="False" hidden="True" includefiles="doc1 doc2 doc3" includehidden="False" maxdepth="-1" numbered="True" parent="intro" rawcaption="" titlesonly="True">

--- a/tests/test_sphinx/test_success_tableofcontents_.xml
+++ b/tests/test_sphinx/test_success_tableofcontents_.xml
@@ -1,0 +1,8 @@
+<document source="intro">
+    <section ids="heading-intro-rst" names="heading:\ intro.rst">
+        <title>
+            Heading: intro.rst
+        <compound classes="toctree-wrapper">
+            <toctree caption="True" entries="(None,\ 'doc1')" glob="False" hidden="False" includefiles="doc1" includehidden="False" maxdepth="-1" numbered="False" parent="intro" rawcaption="" titlesonly="True">
+        <compound classes="toctree-wrapper">
+            <toctree caption="True" entries="(None,\ 'doc2')" glob="False" hidden="False" includefiles="doc2" includehidden="False" maxdepth="-1" numbered="False" parent="intro" rawcaption="" titlesonly="True">

--- a/tests/test_tools/test_file_to_sitemap_tableofcontents_.yml
+++ b/tests/test_tools/test_file_to_sitemap_tableofcontents_.yml
@@ -1,0 +1,4 @@
+- _toc.yml
+- doc1.rst
+- doc2.rst
+- intro.rst


### PR DESCRIPTION
This is a re-working of https://github.com/executablebooks/jupyter-book/pull/757 (by @choldgraf and @AakashGfude), but improved since the replacement is made in the `doctree-read` phase (rather than a post transform) and so does not have to deal with any builder specific logic. Also better warnings and testing 😉 

Note, the current implementation does not wrap the toctrees in `compound(classes=["tableofcontents-wrapper"])`, like in jupyter-book, but I feel this is unnecessary