### PR TITLE
♻️ REFACTOR: toc file top-level structure

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,16 +1,16 @@
 defaults:
   numbered: 3
   titlesonly: false
-main:
-  file: intro
-  title: Introduction
-  parts:
-  - sections:
-    - file: doc1
-    - file: doc2
-      sections:
-      - file: subfolder/doc3
-      - url: https://example.com
-        title: Example Link
-  - sections:
-    - glob: subglobs/glob*
+root: intro
+parts:
+- caption: Part 1
+  sections:
+  - file: doc1
+  - file: doc2
+    sections:
+    - file: subfolder/doc3
+    - url: https://example.com
+      title: Example Link
+- caption: Part 2
+  sections:
+  - glob: subglobs/glob*

--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -158,24 +158,21 @@ def parse_toc_data(data: Dict[str, Any]) -> SiteMap:
     """Parse a dictionary of the ToC."""
     defaults: Dict[str, Any] = data.get("defaults", {})
 
-    if "main" not in data:
-        raise MalformedError("'main' key not present")
-
-    doc_item, docs_list = _parse_doc_item(data["main"], defaults, "main/")
+    doc_item, docs_list = _parse_doc_item(data, defaults, "/", file_key="root")
 
     site_map = SiteMap(root=doc_item, meta=data.get("meta"))
 
-    _parse_docs_list(docs_list, site_map, defaults, "main/")
+    _parse_docs_list(docs_list, site_map, defaults, "/")
 
     return site_map
 
 
 def _parse_doc_item(
-    data: Dict[str, Any], defaults: Dict[str, Any], path: str
+    data: Dict[str, Any], defaults: Dict[str, Any], path: str, file_key: str = "file"
 ) -> Tuple[DocItem, Sequence[Dict[str, Any]]]:
     """Parse a single doc item."""
-    if "file" not in data:
-        raise MalformedError(f"'file' key not found: '{path}'")
+    if file_key not in data:
+        raise MalformedError(f"'{file_key}' key not found: '{path}'")
     if "sections" in data:
         # this is a shorthand for defining a single part
         if "parts" in data:
@@ -224,7 +221,7 @@ def _parse_doc_item(
         # TODO this is a hacky fix for the fact that sphinx logs a warning
         # for nested toctrees, see:
         # sphinx/environment/collectors/toctree.py::TocTreeCollector::assign_section_numbers::_walk_toctree
-        if keywords.get("numbered") and path != "main/":
+        if keywords.get("numbered") and path != "/":
             keywords.pop("numbered")
 
         try:
@@ -234,7 +231,7 @@ def _parse_doc_item(
         parts.append(toc_item)
 
     try:
-        doc_item = DocItem(docname=data["file"], title=data.get("title"), parts=parts)
+        doc_item = DocItem(docname=data[file_key], title=data.get("title"), parts=parts)
     except TypeError as exc:
         raise MalformedError(f"doc validation: {path}") from exc
 

--- a/tests/_toc_files/basic.yml
+++ b/tests/_toc_files/basic.yml
@@ -1,17 +1,15 @@
 defaults:
   numbered: true
-main:
-  file: intro
-  title: Introduction
-  parts:
-    - caption: Part Caption
-      sections:
-      - file: doc1
-      - file: doc2
-      - file: doc3
-        parts:
-        - sections:
-          - file: subfolder/doc4
-          - url: https://example.com
+root: intro
+parts:
+  - caption: Part Caption
+    sections:
+    - file: doc1
+    - file: doc2
+    - file: doc3
+      parts:
+      - sections:
+        - file: subfolder/doc4
+        - url: https://example.com
 meta:
   regress: intro

--- a/tests/_toc_files/basic_compressed.yml
+++ b/tests/_toc_files/basic_compressed.yml
@@ -1,14 +1,12 @@
 defaults:
   numbered: true
-main:
-  file: intro
-  title: Introduction
+root: intro
+sections:
+- file: doc1
+- file: doc2
+- file: doc3
   sections:
-  - file: doc1
-  - file: doc2
-  - file: doc3
-    sections:
-    - file: doc4
-    - url: https://example.com
+  - file: doc4
+  - url: https://example.com
 meta:
   regress: intro

--- a/tests/_toc_files/exclude_missing.yml
+++ b/tests/_toc_files/exclude_missing.yml
@@ -1,8 +1,7 @@
-main:
-  file: intro
-  sections:
-  - file: doc1
-  - glob: subfolder/other*
+root: intro
+sections:
+- file: doc1
+- glob: subfolder/other*
 meta:
   create_files:
   - doc2

--- a/tests/_toc_files/glob.yml
+++ b/tests/_toc_files/glob.yml
@@ -1,8 +1,6 @@
-main:
-  file: intro
-  title: Introduction
-  sections:
-  - glob: doc*
+root: intro
+sections:
+- glob: doc*
 meta:
   create_files:
   - doc1

--- a/tests/_toc_files/tableofcontents.yml
+++ b/tests/_toc_files/tableofcontents.yml
@@ -1,10 +1,9 @@
-main:
-  file: intro
-  parts:
-  - sections:
-    - file: doc1
-  - sections:
-    - file: doc2
+root: intro
+parts:
+- sections:
+  - file: doc1
+- sections:
+  - file: doc2
 meta:
   create_append:
     intro: |

--- a/tests/_warning_toc_files/contains_toctree.yml
+++ b/tests/_warning_toc_files/contains_toctree.yml
@@ -1,5 +1,4 @@
-main:
-  file: intro
+root: intro
 meta:
   create_files:
   - doc1

--- a/tests/_warning_toc_files/file_not_in_toc.yml
+++ b/tests/_warning_toc_files/file_not_in_toc.yml
@@ -1,5 +1,4 @@
-main:
-  file: intro
+root: intro
 meta:
   create_files:
   - doc1

--- a/tests/_warning_toc_files/multiple_tableofcontents.yml
+++ b/tests/_warning_toc_files/multiple_tableofcontents.yml
@@ -1,7 +1,6 @@
-main:
-  file: intro
-  sections:
-  - file: doc1
+root: intro
+sections:
+- file: doc1
 meta:
   create_append:
     intro: |

--- a/tests/_warning_toc_files/no_glob_match.yml
+++ b/tests/_warning_toc_files/no_glob_match.yml
@@ -1,6 +1,5 @@
-main:
-  file: intro
-  sections:
-  - glob: doc*
+root: intro
+sections:
+- glob: doc*
 meta:
   expected_warning: toctree glob pattern

--- a/tests/_warning_toc_files/tableofcontents_no_toc.yml
+++ b/tests/_warning_toc_files/tableofcontents_no_toc.yml
@@ -1,5 +1,4 @@
-main:
-  file: intro
+root: intro
 meta:
   create_append:
     intro: |

--- a/tests/test_api/test_file_to_sitemap_basic_.yml
+++ b/tests/test_api/test_file_to_sitemap_basic_.yml
@@ -32,7 +32,7 @@ intro:
     - doc2
     - doc3
     titlesonly: true
-  title: Introduction
+  title: null
 subfolder/doc4:
   docname: subfolder/doc4
   parts: []

--- a/tests/test_api/test_file_to_sitemap_basic_compressed_.yml
+++ b/tests/test_api/test_file_to_sitemap_basic_compressed_.yml
@@ -36,4 +36,4 @@ intro:
     - doc2
     - doc3
     titlesonly: true
-  title: Introduction
+  title: null

--- a/tests/test_api/test_file_to_sitemap_glob_.yml
+++ b/tests/test_api/test_file_to_sitemap_glob_.yml
@@ -13,4 +13,4 @@ intro:
     sections:
     - doc*
     titlesonly: true
-  title: Introduction
+  title: null


### PR DESCRIPTION
The root file is now specified under the `root` key,
and the initial `parts`/`sections` are at the top-level.