### PR TITLE
🐛 FIX: Remove `docname_join` use

### DIFF
--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -1,5 +1,5 @@
 """ """
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
 
@@ -160,6 +160,9 @@ def parse_toc_yaml(path: Union[str, Path], encoding: str = "utf8") -> SiteMap:
 
 def parse_toc_data(data: Dict[str, Any]) -> SiteMap:
     """Parse a dictionary of the ToC."""
+    if not isinstance(data, Mapping):
+        MalformedError(f"toc is not a mapping: {type(data)}")
+
     defaults: Dict[str, Any] = data.get("defaults", {})
 
     doc_item, docs_list = _parse_doc_item(data, defaults, "/", file_key="root")

--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -10,7 +10,7 @@ from sphinx.config import Config
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import ExtensionError
 from sphinx.transforms import SphinxTransform
-from sphinx.util import docname_join, logging
+from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.matching import Matcher, patfilter, patmatch
 
@@ -217,7 +217,7 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
             elif isinstance(entry, FileItem):
 
                 child_doc_item = site_map[entry]
-                docname = docname_join(app.env.docname, str(entry))
+                docname = str(entry)
                 title = child_doc_item.title
 
                 # remove any suffixes
@@ -239,7 +239,7 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
                     subnode["includefiles"].append(docname)
 
             elif isinstance(entry, GlobItem):
-                patname = docname_join(app.env.docname, str(entry))
+                patname = str(entry)
                 docnames = sorted(patfilter(all_docnames, patname))
                 for docname in docnames:
                     all_docnames.remove(docname)  # don't include it again

--- a/tests/_toc_files/nested.yml
+++ b/tests/_toc_files/nested.yml
@@ -1,0 +1,11 @@
+root: intro
+sections:
+- file: folder/doc1
+- file: folder/doc2
+- file: folder/doc3
+  sections:
+  - file: folder/subfolder/doc4
+  - glob: folder/globfolder/*
+meta:
+  create_files:
+  - folder/globfolder/glob1

--- a/tests/test_api/test_create_toc_dict_nested_.yml
+++ b/tests/test_api/test_create_toc_dict_nested_.yml
@@ -1,0 +1,11 @@
+meta:
+  create_files:
+  - folder/globfolder/glob1
+root: intro
+sections:
+- file: folder/doc1
+- file: folder/doc2
+- file: folder/doc3
+  sections:
+  - file: folder/subfolder/doc4
+  - glob: folder/globfolder/*

--- a/tests/test_api/test_file_to_sitemap_nested_.yml
+++ b/tests/test_api/test_file_to_sitemap_nested_.yml
@@ -1,0 +1,39 @@
+_meta:
+  create_files:
+  - folder/globfolder/glob1
+_root: intro
+folder/doc1:
+  docname: folder/doc1
+  parts: []
+  title: null
+folder/doc2:
+  docname: folder/doc2
+  parts: []
+  title: null
+folder/doc3:
+  docname: folder/doc3
+  parts:
+  - caption: null
+    numbered: false
+    reversed: false
+    sections:
+    - folder/subfolder/doc4
+    - folder/globfolder/*
+    titlesonly: true
+  title: null
+folder/subfolder/doc4:
+  docname: folder/subfolder/doc4
+  parts: []
+  title: null
+intro:
+  docname: intro
+  parts:
+  - caption: null
+    numbered: false
+    reversed: false
+    sections:
+    - folder/doc1
+    - folder/doc2
+    - folder/doc3
+    titlesonly: true
+  title: null

--- a/tests/test_tools/test_file_to_sitemap_nested_.yml
+++ b/tests/test_tools/test_file_to_sitemap_nested_.yml
@@ -1,0 +1,10 @@
+- _toc.yml
+- folder
+- folder/doc1.rst
+- folder/doc2.rst
+- folder/doc3.rst
+- folder/globfolder
+- folder/globfolder/glob1.rst
+- folder/subfolder
+- folder/subfolder/doc4.rst
+- intro.rst


### PR DESCRIPTION
This is not required, because the docnames
are all relative to the source folder,
rather than to the file their `toctree` is in.