### PR TITLE
♻️ REFACTOR: API naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,11 @@ repos:
     - id: trailing-whitespace
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.44"
+    rev: "0.46"
     hooks:
     - id: check-manifest
+      args: [--no-build-isolation]
+      additional_dependencies: [setuptools>=46.4.0]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ sections:
 
 ## API
 
-The ToC file is parsed to a `SiteMap`, which is a `MutableMapping` subclass, with keys representing docnames mapping to a `DocItem` that stores information on the toctrees it should contain:
+The ToC file is parsed to a `SiteMap`, which is a `MutableMapping` subclass, with keys representing docnames mapping to a `Document` that stores information on the toctrees it should contain:
 
 ```python
 import yaml
@@ -334,21 +334,23 @@ yaml.dump(site_map.as_json())
 Would produce e.g.
 
 ```yaml
-_root: intro
-doc1:
-  docname: doc1
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: Part Caption
-    numbered: true
-    reversed: false
-    sections:
-    - doc1
-    titlesonly: true
-  title: null
+root: intro
+documents:
+  doc1:
+    docname: doc1
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: Part Caption
+      numbered: true
+      reversed: false
+      items:
+      - doc1
+      titlesonly: true
+    title: null
+meta: {}
 ```
 
 ## Development Notes

--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -28,11 +28,11 @@ class UrlItem:
 
 
 @attr.s(slots=True)
-class TocItem:
+class TocTree:
     """An individual toctree within a document."""
 
     # TODO validate uniqueness of docnames (at least one item)
-    sections: List[Union[GlobItem, FileItem, UrlItem]] = attr.ib(
+    items: List[Union[GlobItem, FileItem, UrlItem]] = attr.ib(
         validator=deep_iterable(
             instance_of((GlobItem, FileItem, UrlItem)), instance_of(list)
         )
@@ -49,47 +49,43 @@ class TocItem:
     titlesonly: bool = attr.ib(True, kw_only=True, validator=instance_of(bool))
 
     def files(self) -> List[str]:
-        return [
-            str(section) for section in self.sections if isinstance(section, FileItem)
-        ]
+        return [str(item) for item in self.items if isinstance(item, FileItem)]
 
     def globs(self) -> List[str]:
-        return [
-            str(section) for section in self.sections if isinstance(section, GlobItem)
-        ]
+        return [str(item) for item in self.items if isinstance(item, GlobItem)]
 
 
 @attr.s(slots=True)
-class DocItem:
+class Document:
     """A document in the site map."""
 
     docname: str = attr.ib(validator=instance_of(str))
     title: Optional[str] = attr.ib(None, validator=optional(instance_of(str)))
     # TODO validate uniqueness of docnames across all parts (and none should be the docname)
-    parts: List[TocItem] = attr.ib(
-        factory=list, validator=deep_iterable(instance_of(TocItem), instance_of(list))
+    subtrees: List[TocTree] = attr.ib(
+        factory=list, validator=deep_iterable(instance_of(TocTree), instance_of(list))
     )
 
     def child_files(self) -> List[str]:
         """Return all children files."""
-        return [name for part in self.parts for name in part.files()]
+        return [name for tree in self.subtrees for name in tree.files()]
 
     def child_globs(self) -> List[str]:
         """Return all children globs."""
-        return [name for part in self.parts for name in part.globs()]
+        return [name for tree in self.subtrees for name in tree.globs()]
 
 
 class SiteMap(MutableMapping):
     """A mapping of documents to their toctrees (or None if terminal)."""
 
-    def __init__(self, root: DocItem, meta: Optional[Dict[str, Any]] = None) -> None:
-        self._docs: Dict[str, DocItem] = {}
+    def __init__(self, root: Document, meta: Optional[Dict[str, Any]] = None) -> None:
+        self._docs: Dict[str, Document] = {}
         self[root.docname] = root
-        self._root: DocItem = root
+        self._root: Document = root
         self._meta: Dict[str, Any] = meta or {}
 
     @property
-    def root(self) -> DocItem:
+    def root(self) -> Document:
         """Return the root document."""
         return self._root
 
@@ -102,10 +98,10 @@ class SiteMap(MutableMapping):
         """Return set of all globs present across all toctrees."""
         return {glob for item in self._docs.values() for glob in item.child_globs()}
 
-    def __getitem__(self, docname: str) -> DocItem:
+    def __getitem__(self, docname: str) -> Document:
         return self._docs[docname]
 
-    def __setitem__(self, docname: str, item: DocItem) -> None:
+    def __setitem__(self, docname: str, item: Document) -> None:
         assert item.docname == docname
         self._docs[docname] = item
 
@@ -130,17 +126,12 @@ class SiteMap(MutableMapping):
             return str(value)
         return value
 
-    def as_json(
-        self, root_key: str = "_root", meta_key: str = "_meta"
-    ) -> Dict[str, Any]:
+    def as_json(self) -> Dict[str, Any]:
         """Return JSON serialized site-map representation."""
-        dct = {
-            k: attr.asdict(v, value_serializer=self._serializer) if v else v
-            for k, v in self._docs.items()
+        doc_dict = {
+            k: attr.asdict(self._docs[k], value_serializer=self._serializer)
+            if self._docs[k]
+            else self._docs[k]
+            for k in sorted(self._docs)
         }
-        assert root_key not in dct
-        dct[root_key] = self.root.docname
-        if self.meta:
-            assert meta_key not in dct
-            dct[meta_key] = self.meta
-        return dct
+        return {"root": self.root.docname, "documents": doc_dict, "meta": self.meta}

--- a/sphinx_external_toc/cli.py
+++ b/sphinx_external_toc/cli.py
@@ -23,7 +23,7 @@ def main():
 def parse_toc(toc_file):
     """Parse a ToC file to a site-map YAML."""
     site_map = parse_toc_yaml(toc_file)
-    click.echo(yaml.dump(site_map.as_json()))
+    click.echo(yaml.dump(site_map.as_json(), sort_keys=False, default_flow_style=False))
 
 
 @main.command("create-site")

--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -14,7 +14,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.matching import Matcher, patfilter, patmatch
 
-from .api import DocItem, FileItem, GlobItem, SiteMap, UrlItem
+from .api import Document, FileItem, GlobItem, SiteMap, UrlItem
 from .parsing import parse_toc_yaml
 
 logger = logging.getLogger(__name__)
@@ -166,9 +166,9 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
     )
 
     site_map: SiteMap = app.env.external_site_map
-    doc_item: Optional[DocItem] = site_map.get(app.env.docname)
+    doc_item: Optional[Document] = site_map.get(app.env.docname)
 
-    if doc_item is None or not doc_item.parts:
+    if doc_item is None or not doc_item.subtrees:
         if toc_placeholders:
             create_warning(
                 app,
@@ -199,7 +199,7 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
 
     node_list: List[nodes.Element] = []
 
-    for toctree in doc_item.parts:
+    for toctree in doc_item.subtrees:
 
         subnode = toctree_node()
         subnode["parent"] = app.env.docname
@@ -211,7 +211,7 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
         # TODO this wasn't in the original code,
         # but alabaster theme intermittently raised `KeyError('rawcaption')`
         subnode["rawcaption"] = toctree.caption or ""
-        subnode["glob"] = any(isinstance(entry, GlobItem) for entry in toctree.sections)
+        subnode["glob"] = any(isinstance(entry, GlobItem) for entry in toctree.items)
         subnode["hidden"] = False if toc_placeholders else toctree.hidden
         subnode["includehidden"] = False
         subnode["numbered"] = (
@@ -223,7 +223,7 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
         wrappernode = nodes.compound(classes=["toctree-wrapper"])
         wrappernode.append(subnode)
 
-        for entry in toctree.sections:
+        for entry in toctree.items:
 
             if isinstance(entry, UrlItem):
 

--- a/sphinx_external_toc/tools.py
+++ b/sphinx_external_toc/tools.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, MutableMapping, Optional, Sequence, Tuple, Unio
 
 import yaml
 
-from .api import DocItem, FileItem, SiteMap, TocItem
+from .api import Document, FileItem, SiteMap, TocTree
 from .parsing import MalformedError, parse_toc_yaml
 
 
@@ -129,7 +129,7 @@ def create_site_map_from_path(
     # we add all files to the site map, even if they don't have descendants
     # so we may later change their title
     for root_file in root_files:
-        site_map[root_file] = DocItem(root_file)
+        site_map[root_file] = Document(root_file)
 
     # while there are subfolders add them to the site-map
     while indexed_folders:
@@ -137,7 +137,7 @@ def create_site_map_from_path(
         for child_file in child_files:
             child_docname = (sub_path / child_file).relative_to(root_path).as_posix()
             assert child_docname not in site_map
-            site_map[child_docname] = DocItem(child_docname)
+            site_map[child_docname] = Document(child_docname)
         doc_item, new_indexed_folders = _doc_item_from_path(
             root_path,
             sub_path,
@@ -164,7 +164,7 @@ def _doc_item_from_path(
     default_index: str,
     ignore_matches: Sequence[str],
 ):
-    """Return the ``DocItem`` and children folders that contain an index."""
+    """Return the ``Document`` and children folders that contain an index."""
     file_items = [
         FileItem((folder / name).relative_to(root).as_posix())
         for name in other_docnames
@@ -186,9 +186,9 @@ def _doc_item_from_path(
             FileItem((sub_folder / child_index).relative_to(root).as_posix())
         )
 
-    doc_item = DocItem(
+    doc_item = Document(
         docname=(folder / index_docname).relative_to(root).as_posix(),
-        parts=[TocItem(sections=file_items + index_items)]  # type: ignore[arg-type]
+        subtrees=[TocTree(items=file_items + index_items)]  # type: ignore[arg-type]
         if (file_items or index_items)
         else [],
     )

--- a/tests/test_parsing/test_create_toc_dict_basic_.yml
+++ b/tests/test_parsing/test_create_toc_dict_basic_.yml
@@ -1,13 +1,13 @@
 meta:
   regress: intro
-parts:
-- caption: Part Caption
+options:
+  caption: Part Caption
   numbered: true
-  sections:
-  - file: doc1
-  - file: doc2
-  - file: doc3
-    sections:
-    - file: subfolder/doc4
-    - url: https://example.com
 root: intro
+sections:
+- file: doc1
+- file: doc2
+- file: doc3
+  sections:
+  - file: subfolder/doc4
+  - url: https://example.com

--- a/tests/test_parsing/test_create_toc_dict_basic_compressed_.yml
+++ b/tests/test_parsing/test_create_toc_dict_basic_compressed_.yml
@@ -1,12 +1,12 @@
 meta:
   regress: intro
-parts:
-- numbered: true
-  sections:
-  - file: doc1
-  - file: doc2
-  - file: doc3
-    sections:
-    - file: doc4
-    - url: https://example.com
+options:
+  numbered: true
 root: intro
+sections:
+- file: doc1
+- file: doc2
+- file: doc3
+  sections:
+  - file: doc4
+  - url: https://example.com

--- a/tests/test_parsing/test_file_to_sitemap_basic_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_basic_.yml
@@ -1,43 +1,44 @@
-_meta:
+documents:
+  doc1:
+    docname: doc1
+    subtrees: []
+    title: null
+  doc2:
+    docname: doc2
+    subtrees: []
+    title: null
+  doc3:
+    docname: doc3
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - subfolder/doc4
+      - title: null
+        url: https://example.com
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: Part Caption
+      hidden: true
+      items:
+      - doc1
+      - doc2
+      - doc3
+      maxdepth: -1
+      numbered: true
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder/doc4:
+    docname: subfolder/doc4
+    subtrees: []
+    title: null
+meta:
   regress: intro
-_root: intro
-doc1:
-  docname: doc1
-  parts: []
-  title: null
-doc2:
-  docname: doc2
-  parts: []
-  title: null
-doc3:
-  docname: doc3
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - subfolder/doc4
-    - title: null
-      url: https://example.com
-    titlesonly: true
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: Part Caption
-    hidden: true
-    maxdepth: -1
-    numbered: true
-    reversed: false
-    sections:
-    - doc1
-    - doc2
-    - doc3
-    titlesonly: true
-  title: null
-subfolder/doc4:
-  docname: subfolder/doc4
-  parts: []
-  title: null
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_basic_compressed_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_basic_compressed_.yml
@@ -1,43 +1,44 @@
-_meta:
+documents:
+  doc1:
+    docname: doc1
+    subtrees: []
+    title: null
+  doc2:
+    docname: doc2
+    subtrees: []
+    title: null
+  doc3:
+    docname: doc3
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - doc4
+      - title: null
+        url: https://example.com
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  doc4:
+    docname: doc4
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - doc1
+      - doc2
+      - doc3
+      maxdepth: -1
+      numbered: true
+      reversed: false
+      titlesonly: true
+    title: null
+meta:
   regress: intro
-_root: intro
-doc1:
-  docname: doc1
-  parts: []
-  title: null
-doc2:
-  docname: doc2
-  parts: []
-  title: null
-doc3:
-  docname: doc3
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - doc4
-    - title: null
-      url: https://example.com
-    titlesonly: true
-  title: null
-doc4:
-  docname: doc4
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: true
-    reversed: false
-    sections:
-    - doc1
-    - doc2
-    - doc3
-    titlesonly: true
-  title: null
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_exclude_missing_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_exclude_missing_.yml
@@ -1,23 +1,24 @@
-_meta:
+documents:
+  doc1:
+    docname: doc1
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - doc1
+      - subfolder/other*
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+meta:
   create_files:
   - doc2
   - subfolder/other1
   exclude_missing: true
-_root: intro
-doc1:
-  docname: doc1
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - doc1
-    - subfolder/other*
-    titlesonly: true
-  title: null
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_glob_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_glob_.yml
@@ -1,18 +1,19 @@
-_meta:
+documents:
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - doc*
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+meta:
   create_files:
   - doc1
   - doc2
   - doc3
-_root: intro
-intro:
-  docname: intro
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - doc*
-    titlesonly: true
-  title: null
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_nested_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_nested_.yml
@@ -1,43 +1,44 @@
-_meta:
+documents:
+  folder/doc1:
+    docname: folder/doc1
+    subtrees: []
+    title: null
+  folder/doc2:
+    docname: folder/doc2
+    subtrees: []
+    title: null
+  folder/doc3:
+    docname: folder/doc3
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - folder/subfolder/doc4
+      - folder/globfolder/*
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  folder/subfolder/doc4:
+    docname: folder/subfolder/doc4
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - folder/doc1
+      - folder/doc2
+      - folder/doc3
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+meta:
   create_files:
   - folder/globfolder/glob1
-_root: intro
-folder/doc1:
-  docname: folder/doc1
-  parts: []
-  title: null
-folder/doc2:
-  docname: folder/doc2
-  parts: []
-  title: null
-folder/doc3:
-  docname: folder/doc3
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - folder/subfolder/doc4
-    - folder/globfolder/*
-    titlesonly: true
-  title: null
-folder/subfolder/doc4:
-  docname: folder/subfolder/doc4
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - folder/doc1
-    - folder/doc2
-    - folder/doc3
-    titlesonly: true
-  title: null
+root: intro

--- a/tests/test_parsing/test_file_to_sitemap_tableofcontents_.yml
+++ b/tests/test_parsing/test_file_to_sitemap_tableofcontents_.yml
@@ -1,35 +1,36 @@
-_meta:
+documents:
+  doc1:
+    docname: doc1
+    subtrees: []
+    title: null
+  doc2:
+    docname: doc2
+    subtrees: []
+    title: null
+  intro:
+    docname: intro
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - doc1
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    - caption: null
+      hidden: true
+      items:
+      - doc2
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+meta:
   create_append:
     intro: '.. tableofcontents::
 
       '
   regress: intro
-_root: intro
-doc1:
-  docname: doc1
-  parts: []
-  title: null
-doc2:
-  docname: doc2
-  parts: []
-  title: null
-intro:
-  docname: intro
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - doc1
-    titlesonly: true
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - doc2
-    titlesonly: true
-  title: null
+root: intro

--- a/tests/test_tools/test_create_site_map_from_path.yml
+++ b/tests/test_tools/test_create_site_map_from_path.yml
@@ -1,90 +1,92 @@
-11_other:
-  docname: 11_other
-  parts: []
-  title: null
-1_other:
-  docname: 1_other
-  parts: []
-  title: null
-_root: index
-index:
-  docname: index
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - 1_other
-    - 11_other
-    - subfolder1/index
-    - subfolder2/index
-    - subfolder3/no_index1
-    - subfolder14/index
-    titlesonly: true
-  title: null
-subfolder1/index:
-  docname: subfolder1/index
-  parts: []
-  title: null
-subfolder14/index:
-  docname: subfolder14/index
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - subfolder14/subsubfolder/index
-    titlesonly: true
-  title: null
-subfolder14/subsubfolder/index:
-  docname: subfolder14/subsubfolder/index
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - subfolder14/subsubfolder/other
-    titlesonly: true
-  title: null
-subfolder14/subsubfolder/other:
-  docname: subfolder14/subsubfolder/other
-  parts: []
-  title: null
-subfolder2/index:
-  docname: subfolder2/index
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - subfolder2/other
-    titlesonly: true
-  title: null
-subfolder2/other:
-  docname: subfolder2/other
-  parts: []
-  title: null
-subfolder3/no_index1:
-  docname: subfolder3/no_index1
-  parts:
-  - caption: null
-    hidden: true
-    maxdepth: -1
-    numbered: false
-    reversed: false
-    sections:
-    - subfolder3/no_index2
-    titlesonly: true
-  title: null
-subfolder3/no_index2:
-  docname: subfolder3/no_index2
-  parts: []
-  title: null
+documents:
+  11_other:
+    docname: 11_other
+    subtrees: []
+    title: null
+  1_other:
+    docname: 1_other
+    subtrees: []
+    title: null
+  index:
+    docname: index
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - 1_other
+      - 11_other
+      - subfolder1/index
+      - subfolder2/index
+      - subfolder3/no_index1
+      - subfolder14/index
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder1/index:
+    docname: subfolder1/index
+    subtrees: []
+    title: null
+  subfolder14/index:
+    docname: subfolder14/index
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - subfolder14/subsubfolder/index
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder14/subsubfolder/index:
+    docname: subfolder14/subsubfolder/index
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - subfolder14/subsubfolder/other
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder14/subsubfolder/other:
+    docname: subfolder14/subsubfolder/other
+    subtrees: []
+    title: null
+  subfolder2/index:
+    docname: subfolder2/index
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - subfolder2/other
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder2/other:
+    docname: subfolder2/other
+    subtrees: []
+    title: null
+  subfolder3/no_index1:
+    docname: subfolder3/no_index1
+    subtrees:
+    - caption: null
+      hidden: true
+      items:
+      - subfolder3/no_index2
+      maxdepth: -1
+      numbered: false
+      reversed: false
+      titlesonly: true
+    title: null
+  subfolder3/no_index2:
+    docname: subfolder3/no_index2
+    subtrees: []
+    title: null
+meta: {}
+root: index


### PR DESCRIPTION
Renamed to be more general:

- `DocItem` -> `Document`
- `DocItem.parts` -> `Document.subtrees`
- `TocItem` -> `TocTree`
- `TocItem.sections` -> `TocTree.items`