### PR TITLE
🔧 MAINT: Renaming site to files in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,16 +287,16 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  from-site  Create a ToC file from a site directory.
+  from-files  Create a ToC file from a site directory.
   migrate    Migrate a ToC from a previous revision.
   parse      Parse a ToC file to a site-map YAML.
-  to-site    Create a site directory from a ToC file.
+  to-files    Create a site directory from a ToC file.
 ```
 
 To build a template site from only a ToC file:
 
 ```console
-$ sphinx-etoc to-site -p path/to/site -e rst path/to/_toc.yml
+$ sphinx-etoc to-files -p path/to/site -e rst path/to/_toc.yml
 ```
 
 Note, you can also add additional files in `meta`/`create_files` amd append text to the end of files with `meta`/`create_append`, e.g.
@@ -319,7 +319,7 @@ meta:
 To build a ToC file from an existing site:
 
 ```console
-$ sphinx-etoc from-site path/to/folder
+$ sphinx-etoc from-files path/to/folder
 ```
 
 Some rules used:
@@ -356,7 +356,7 @@ index.rst
 will create the ToC:
 
 ```console
-$ sphinx-etoc from-site path/to/folder -i index -s ".*" -e ".rst" -t
+$ sphinx-etoc from-files path/to/folder -i index -s ".*" -e ".rst" -t
 root: index
 entries:
 - file: 1_a_title

--- a/README.md
+++ b/README.md
@@ -287,16 +287,16 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  from-files  Create a ToC file from a site directory.
+  from-project  Create a ToC file from a site directory.
   migrate    Migrate a ToC from a previous revision.
   parse      Parse a ToC file to a site-map YAML.
-  to-files    Create a site directory from a ToC file.
+  to-project    Create a site directory from a ToC file.
 ```
 
 To build a template site from only a ToC file:
 
 ```console
-$ sphinx-etoc to-files -p path/to/site -e rst path/to/_toc.yml
+$ sphinx-etoc to-project -p path/to/site -e rst path/to/_toc.yml
 ```
 
 Note, you can also add additional files in `meta`/`create_files` amd append text to the end of files with `meta`/`create_append`, e.g.
@@ -319,7 +319,7 @@ meta:
 To build a ToC file from an existing site:
 
 ```console
-$ sphinx-etoc from-files path/to/folder
+$ sphinx-etoc from-project path/to/folder
 ```
 
 Some rules used:
@@ -356,7 +356,7 @@ index.rst
 will create the ToC:
 
 ```console
-$ sphinx-etoc from-files path/to/folder -i index -s ".*" -e ".rst" -t
+$ sphinx-etoc from-project path/to/folder -i index -s ".*" -e ".rst" -t
 root: index
 entries:
 - file: 1_a_title

--- a/README.md
+++ b/README.md
@@ -287,13 +287,13 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  from-project  Create a ToC file from a site directory.
+  from-project  Create a ToC file from a project directory.
   migrate    Migrate a ToC from a previous revision.
   parse      Parse a ToC file to a site-map YAML.
-  to-project    Create a site directory from a ToC file.
+  to-project    Create a project directory from a ToC file.
 ```
 
-To build a template site from only a ToC file:
+To build a template project from only a ToC file:
 
 ```console
 $ sphinx-etoc to-project -p path/to/site -e rst path/to/_toc.yml
@@ -335,7 +335,7 @@ The command can also guess a `title` for each file, based on its path:
 - Words are split by `_`
 - The first "word" is removed if it is an integer
 
-For example, for a site with files:
+For example, for a project with files:
 
 ```
 index.rst

--- a/sphinx_external_toc/__init__.py
+++ b/sphinx_external_toc/__init__.py
@@ -1,4 +1,4 @@
-"""A sphinx extension that allows the site toctree to be defined in a single file."""
+"""A sphinx extension that allows the project toctree to be defined in a single file."""
 
 __version__ = "0.1.0"
 

--- a/sphinx_external_toc/cli.py
+++ b/sphinx_external_toc/cli.py
@@ -26,7 +26,7 @@ def parse_toc(toc_file):
     click.echo(yaml.dump(site_map.as_json(), sort_keys=False, default_flow_style=False))
 
 
-@main.command("to-site")
+@main.command("to-files")
 @click.argument("toc_file", type=click.Path(exists=True, file_okay=True))
 @click.option(
     "-p",
@@ -53,7 +53,7 @@ def create_site(toc_file, path, extension, overwrite):
     click.secho("SUCCESS!", fg="green")
 
 
-@main.command("from-site")
+@main.command("from-files")
 @click.argument(
     "site_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
 )

--- a/sphinx_external_toc/cli.py
+++ b/sphinx_external_toc/cli.py
@@ -26,7 +26,7 @@ def parse_toc(toc_file):
     click.echo(yaml.dump(site_map.as_json(), sort_keys=False, default_flow_style=False))
 
 
-@main.command("to-files")
+@main.command("to-project")
 @click.argument("toc_file", type=click.Path(exists=True, file_okay=True))
 @click.option(
     "-p",
@@ -53,7 +53,7 @@ def create_site(toc_file, path, extension, overwrite):
     click.secho("SUCCESS!", fg="green")
 
 
-@main.command("from-files")
+@main.command("from-project")
 @click.argument(
     "site_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
 )

--- a/sphinx_external_toc/cli.py
+++ b/sphinx_external_toc/cli.py
@@ -45,7 +45,7 @@ def parse_toc(toc_file):
 )
 @click.option("-o", "--overwrite", is_flag=True, help="Overwrite existing files.")
 def create_site(toc_file, path, extension, overwrite):
-    """Create a site directory from a ToC file."""
+    """Create a project directory from a ToC file."""
     create_site_from_toc(
         toc_file, root_path=path, default_ext="." + extension, overwrite=overwrite
     )
@@ -95,7 +95,7 @@ def create_site(toc_file, path, extension, overwrite):
     help="The key-mappings to use.",
 )
 def create_toc(site_dir, extension, index, skip_match, guess_titles, file_format):
-    """Create a ToC file from a site directory."""
+    """Create a ToC file from a project directory."""
     site_map = create_site_map_from_path(
         site_dir,
         suffixes=extension,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_parse_toc(invoke_cli):
 
 
 def test_create_toc(tmp_path, invoke_cli, file_regression):
-    # create site files
+    # create project files
     files = [
         "index.rst",
         "1_a_title.rst",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,7 +26,7 @@ def test_file_to_sitemap(path: Path, tmp_path: Path, data_regression):
 
 def test_create_site_map_from_path(tmp_path: Path, data_regression):
 
-    # create site files
+    # create project files
     files = [
         "index.rst",
         "1_other.rst",


### PR DESCRIPTION
This PR renames the two CLI commands:

- `to-site` and `from-site`

to instead be:

- `to-files` and `from-files`

The rationale for this is to avoid using web-specific terminology (web**site**) and also to be more explicit in what these functions are doing (building a TOC from files on disk, and building files on disk from the TOC).


NOTE: this is a breaking change from an API perspective, since we have technically released 1.0 we should bump to 2.0. Alternatively we could use [click aliases](https://github.com/click-contrib/click-aliases) to allow for both commands to be used?