### PR TITLE
👌  IMPROVE: Detecting change in attributes of a toctree for triggering re-builds

### DIFF
--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -49,11 +49,20 @@ class TocTree:
     reversed: bool = attr.ib(False, kw_only=True, validator=instance_of(bool))
     titlesonly: bool = attr.ib(False, kw_only=True, validator=instance_of(bool))
 
+    def __getitem__(self, item):
+        return getattr(self, item)
+    
+    def __setitem__(self, attr, item):
+        return setattr(self, attr, item)
+
     def files(self) -> List[str]:
         return [str(item) for item in self.items if isinstance(item, FileItem)]
 
     def globs(self) -> List[str]:
         return [str(item) for item in self.items if isinstance(item, GlobItem)]
+    
+    def options(self) -> List[str]:
+        return [str(item) for item in dir(self) if not item.startswith('__') and not callable(self[item])]
 
 
 @attr.s(slots=True)
@@ -74,6 +83,10 @@ class Document:
     def child_globs(self) -> List[str]:
         """Return all children globs."""
         return [name for tree in self.subtrees for name in tree.globs()]
+    
+    def child_options(self) -> List[str]:
+        """Return all children options. """
+        return set(name for tree in self.subtrees for name in tree.options())
 
 
 class SiteMap(MutableMapping):

--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -51,7 +51,7 @@ class TocTree:
 
     def __getitem__(self, item):
         return getattr(self, item)
-    
+
     def __setitem__(self, attr, item):
         return setattr(self, attr, item)
 
@@ -60,9 +60,13 @@ class TocTree:
 
     def globs(self) -> List[str]:
         return [str(item) for item in self.items if isinstance(item, GlobItem)]
-    
+
     def options(self) -> List[str]:
-        return [str(item) for item in dir(self) if not item.startswith('__') and not callable(self[item])]
+        return [
+            str(item)
+            for item in dir(self)
+            if not item.startswith("__") and not callable(self[item])
+        ]
 
 
 @attr.s(slots=True)
@@ -83,8 +87,8 @@ class Document:
     def child_globs(self) -> List[str]:
         """Return all children globs."""
         return [name for tree in self.subtrees for name in tree.globs()]
-    
-    def child_options(self) -> List[str]:
+
+    def child_options(self) -> Set[str]:
         """Return all children options. """
         return set(name for tree in self.subtrees for name in tree.options())
 

--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -1,6 +1,6 @@
 """Sphinx event functions and directives."""
-import glob
 import copy
+import glob
 from pathlib import Path, PurePosixPath
 from typing import Any, List, Optional, Set
 
@@ -140,7 +140,9 @@ def add_changed_toctrees(
             # comparing attributes with previous map
             if docname in previous_map:
                 val_p = previous_map[docname]
-                for site_map_subtree, previous_map_subtree in zip(val.subtrees, val_p.subtrees):
+                for site_map_subtree, previous_map_subtree in zip(
+                    val.subtrees, val_p.subtrees
+                ):
                     for opt in val.child_options():
                         if site_map_subtree[opt] != previous_map_subtree[opt]:
                             # adding all the docs of the subtree, docname whose option changed
@@ -148,7 +150,7 @@ def add_changed_toctrees(
                             changed_docs.update(site_map_subtree.files())
             else:
                 changed_docs.add(docname)
-        
+
     return changed_docs
 
 

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,14 +1,12 @@
 import os
-import yaml
 from pathlib import Path
 
 import pytest
 from sphinx.testing.path import path as sphinx_path
 from sphinx.testing.util import SphinxTestApp
 
-from sphinx_external_toc.tools import create_site_from_toc
 from sphinx_external_toc.events import add_changed_toctrees
-from sphinx_external_toc.parsing import parse_toc_yaml
+from sphinx_external_toc.tools import create_site_from_toc
 
 TOC_FILES = list(Path(__file__).parent.joinpath("_toc_files").glob("*.yml"))
 TOC_FILES_WARN = list(
@@ -54,6 +52,7 @@ def sphinx_build_factory(make_app):
         return SphinxBuild(app, src_path)
 
     yield _func
+
 
 @pytest.fixture()
 def sphinx_app(make_app):
@@ -156,6 +155,7 @@ external_toc_path = {Path(os.path.abspath(toc_path)).as_posix()!r}
     builder = sphinx_build_factory(src_dir)
     builder.build()
 
+
 def test_changed_toctrees(tmp_path: Path, sphinx_app):
     """Test for tocs with changed toctrees."""
     src_dir = tmp_path / "srcdir"
@@ -173,10 +173,9 @@ external_toc_path = {Path(os.path.abspath(toc_path)).as_posix()!r}
     app = sphinx_app(src_dir)
     changed_files = add_changed_toctrees(app, app.env, set(), set(), set())
 
-    new_toc_path = src_dir / "basic.yml"
-
     # changing numbered option in the toctree
-    app.config.external_site_map['intro'].subtrees[0]['numbered'] = False
+    app.config.external_site_map["intro"].subtrees[0]["numbered"] = False
     changed_files_t = add_changed_toctrees(app, app.env, set(), set(), set())
 
-    assert changed_files_t ==  {'intro', 'doc3', 'doc2', 'doc1'}
+    assert changed_files == set()
+    assert changed_files_t == {"intro", "doc3", "doc2", "doc1"}


### PR DESCRIPTION
The following PR detects changes made to all attributes of a Toctree class including the `options`. And adds that particular subtree, including the parent docname to `changed_docs` for updation during the `env-get-outdated` event.  

fixes https://github.com/executablebooks/sphinx-external-toc/issues/46