### PR TITLE
Remove unnecessary version constraint for click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 packages = find:
 install_requires =
     attrs>=20.3,<22
-    click~=7.1
+    click>=7.1
     pyyaml
     sphinx>=3,<5
 python_requires = ~=3.6


### PR DESCRIPTION
As far as I can tell no `click` features are used that prevent an upgrade to `v8` of click.

See https://github.com/executablebooks/jupyter-book/issues/1590 for more info as to why this is necessary.