### PR TITLE
🐛 FIX: Inserting toctree into empty document

### DIFF
--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -239,7 +239,7 @@ class SiteMap(MutableMapping):
         """
         changed_docs = set()
         # check if the root document has changed
-        if self.root.docname != previous.root.docname:
+        if self.root != previous.root:
             changed_docs.add(self.root.docname)
         for name, doc in self._docs.items():
             if name not in previous:

--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -131,6 +131,7 @@ def add_changed_toctrees(
     """Add docs with new or changed toctrees to changed list."""
     previous_map = getattr(app.env, "external_site_map", None)
     # move external_site_map from config to env
+    site_map: SiteMap
     app.env.external_site_map = site_map = app.config.external_site_map
     # Compare to previous map, to record docnames with new or changed toctrees
     if not previous_map:
@@ -287,11 +288,14 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
 
     if toc_placeholders:
         toc_placeholders[0].replace_self(node_list)
-    else:
+    elif doctree.children and isinstance(doctree.children[-1], nodes.section):
         # note here the toctree cannot not just be appended to the end of the doc,
         # since `TocTreeCollector.process_doc` expects it in a section
+        # otherwise it will result in the child documents being on the same level as this document
         # TODO check if there is this is always ok
         doctree.children[-1].extend(node_list)
+    else:
+        doctree.children.extend(node_list)
 
 
 class InsertToctrees(SphinxTransform):


### PR DESCRIPTION
closes #54

It is interesting to note, that if you insert a toctree under a section, you get the expected behaviour of:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/2997570/163692159-1f2ba825-6a2c-480b-bc7d-138afcdf787f.png">

But, if the document does not have a heading, and so you insert as a direct child of the document. You get:

<img width="238" alt="image" src="https://user-images.githubusercontent.com/2997570/163692196-72953eaf-ef6f-402e-8c64-621f46256599.png">

i.e. you can "hide" the index page

Not sure if this is specific to sphinx-book-theme and/or an expected feature of sphinx