### PR TITLE
Include Titles in FileItems

### DIFF
--- a/sphinx_external_toc/api.py
+++ b/sphinx_external_toc/api.py
@@ -16,14 +16,18 @@ from ._compat import (
 #: Pattern used to match URL items.
 URL_PATTERN: str = r".+://.*"
 
-
-class FileItem(str):
+@dataclass(**DC_SLOTS)
+class FileItem:
     """A document path in a toctree list.
 
     This should be in POSIX format (folders split by ``/``), relative to the
     source directory, and can be with or without an extension.
     """
-
+    path: str = field(validator=[instance_of(str)])
+    title: Optional[str] = field(default=None, validator=optional(instance_of(str)))
+    
+    def __post_init__(self):
+        validate_fields(self)
 
 class GlobItem(str):
     """A document glob in a toctree list."""

--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -251,10 +251,8 @@ def insert_toctrees(app: Sphinx, doctree: nodes.document) -> None:
                 subnode["entries"].append((entry.title, entry.url))
 
             elif isinstance(entry, FileItem):
-
-                child_doc_item = site_map[entry]
-                docname = str(entry)
-                title = child_doc_item.title
+                docname = entry.path
+                title = entry.title
 
                 docname = remove_suffix(docname, app.config.source_suffix)
 

--- a/sphinx_external_toc/parsing.py
+++ b/sphinx_external_toc/parsing.py
@@ -238,7 +238,7 @@ def _parse_doc_item(
 
             try:
                 if link_keys == {FILE_KEY}:
-                    items.append(FileItem(item_data[FILE_KEY]))
+                    items.append(FileItem(item_data[FILE_KEY], item_data.get("title")))
                 elif link_keys == {GLOB_KEY}:
                     items.append(GlobItem(item_data[GLOB_KEY]))
                 elif link_keys == {URL_KEY}:


### PR DESCRIPTION
This fixes an issue where `sphinx-autoupdate` does not pick up changes to titles in the `_toc.yaml` file.

To reproduce, use the example project, 

1. build using `sphinx-autobuild --port 8001 . _build/`
2. add a `title` attributes to one of the files, eg `api.md`
3. change the title int he title attribute

You'll see that the change does not get picked up. The reason is that line 251 of `api.py` does an equality check on the items in the sitemap: `prev_doc = previous[name]`.
Since the title is included in the `Document` class, the changes in 2. and 3. above trigger a rebuild of the `api.md`. But the ToC is injected into the `intro.md` file, which is unchanged both as a file and from the point of view of the `get_changed` function.

By including the titles on `FileItems`, such changes get picked up by `get_changed` and the ToC updates correctly.