### PR TITLE
Fixing simple grammatical error in `index.md`

### DIFF
--- a/docs/example/index.md
+++ b/docs/example/index.md
@@ -1,4 +1,4 @@
 # Example Project
 
 These pages provide an example of different aspects of the ToC.
-See this projects `_toc.yml` for how they are added.
+See this project's `_toc.yml` for how they are added.


### PR DESCRIPTION
Fixes a grammatical error (not "this projects", "this project's").