### PR TITLE
FIX: rework 104 to support e.g. PDFHTML

### DIFF
--- a/sphinx_external_toc/events.py
+++ b/sphinx_external_toc/events.py
@@ -329,12 +329,11 @@ def ensure_index_file(app: Sphinx, exception: Optional[Exception]) -> None:
 
     root_name = remove_suffix(app.config.master_doc, app.config.source_suffix)
 
-    if app.builder.name == "html":
-        redirect_url = f"{root_name}.html"
-    elif app.builder.name == "dirhtml":
+    if app.builder.name == "dirhtml":
         redirect_url = f"{root_name}/index.html"
     else:
-        return
+        # Assume a single index for all non dir-HTML builders
+        redirect_url = f"{root_name}.html"
 
     redirect_text = f'<meta http-equiv="Refresh" content="0; url={redirect_url}" />\n'
     index_path.write_text(redirect_text, encoding="utf8")


### PR DESCRIPTION
It turns out that we want to support transitive HTML builders too. For now, let's rework #104 to assume that any non-dirhtml builder wants an `index.html`.